### PR TITLE
Store table name from collection manager

### DIFF
--- a/collectionmanager.cpp
+++ b/collectionmanager.cpp
@@ -19,6 +19,7 @@ collectionManager::collectionManager(databaseService& _refToDBServInConst, QDial
     newLibName = createDisplay("Library Name");
 
     libraries = createList(libNames);
+    libraries->setSelectionMode(QAbstractItemView::SingleSelection);
 
     collectionMgrLayout->addWidget(newButton, 6, 26, 1, 5);
     collectionMgrLayout->addWidget(openButton, 1, 26, 1, 5);
@@ -73,6 +74,9 @@ collectionManager::~collectionManager()
 
 void collectionManager::openClicked()
 {
+
+    std::string name = libraries->selectedItems().at(0)->text().toStdString();
+    _refToDBServInCllctn.storeTableName(name);
     this->done(1);
 }
 void collectionManager::newClicked()

--- a/dbmanager.cpp
+++ b/dbmanager.cpp
@@ -10,7 +10,8 @@ databaseService::databaseService()
     try
     {
         driver = get_driver_instance();
-        connection = driver->connect("host", "user", "password");
+        connection = driver->connect("tcp://mysql-instance1.cysndijadlug.us-west-2.rds.amazonaws.com:3306",
+                                     "SethTales1015", "PimpFarmer99&");
         connection->setSchema("recLib");
         connection->setAutoCommit(false);
     }catch(sql::SQLException &ex){
@@ -271,6 +272,12 @@ bool databaseService::addNewLib(std::string libName)
         return false;
     }
 
+}
+
+void databaseService::storeTableName(std::string name)
+{
+    tableName = name;
+    std::cout << tableName << std::endl;
 }
 
 //functions for record manager

--- a/dbmanager.h
+++ b/dbmanager.h
@@ -31,6 +31,7 @@ public:
     //functions for collection manager
     std::vector <std::string> getLibNames();
     bool addNewLib(std::string);
+    void storeTableName(std::string);
 
     //functions for record manager
     void addNewRecordToDB(struct record);
@@ -52,6 +53,7 @@ private:
     //member variables for collection manager
     //int ID;
     std::vector <std::string> libNames;
+    std::string tableName;
 
     //member variables for record manager
     QList <record> list;


### PR DESCRIPTION
When user clicks open and a collection is selected, store that collection as the table name