### PR TITLE
Adds logout and change library functionality

### DIFF
--- a/collectionmanager.cpp
+++ b/collectionmanager.cpp
@@ -4,6 +4,7 @@ collectionManager::collectionManager(databaseService& _refToDBServInConst, QDial
     : _refToDBServInCllctn(_refToDBServInConst), QDialog(parent)
 {
     _refToDBServInCllctn = _refToDBServInConst;
+    this->setAttribute(Qt::WA_DeleteOnClose, true);
 
     this->setFixedSize(950, 500);
     this->setWindowTitle("Select or Create Libraries");
@@ -15,6 +16,10 @@ collectionManager::collectionManager(databaseService& _refToDBServInConst, QDial
     newButton = createButton("Create");
     openButton = createButton("Open");
     deleteButton = createButton("Delete");
+    logoutButton = createButton("Logout");
+    logoutButton->setFixedSize(60, 30);
+    quitButton = createButton("Quit");
+    quitButton->setFixedSize(60, 30);
 
     newLibName = createDisplay("Library Name");
 
@@ -24,6 +29,8 @@ collectionManager::collectionManager(databaseService& _refToDBServInConst, QDial
     collectionMgrLayout->addWidget(newButton, 6, 26, 1, 5);
     collectionMgrLayout->addWidget(openButton, 1, 26, 1, 5);
     collectionMgrLayout->addWidget(deleteButton, 48, 26, 1, 5);
+    collectionMgrLayout->addWidget(logoutButton, 48, 36, 1, 5);
+    collectionMgrLayout->addWidget(quitButton, 48, 42, 1, 5);
 
     QLabel *nameLabel = new QLabel;
     nameLabel->setText("Your Collections");
@@ -38,6 +45,8 @@ collectionManager::collectionManager(databaseService& _refToDBServInConst, QDial
     QObject::connect(newButton, SIGNAL(clicked()), this, SLOT(newClicked()));
     QObject::connect(openButton, SIGNAL(clicked()), this, SLOT(openClicked()));
     QObject::connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    QObject::connect(quitButton, SIGNAL(clicked()), this, SLOT(quitClicked()));
+    QObject::connect(logoutButton, SIGNAL(clicked()), this, SLOT(logoutClicked()));
 
 }
 
@@ -164,6 +173,17 @@ void collectionManager::deleteClicked()
            }
         }
     }
+}
+
+void collectionManager::logoutClicked()
+{
+    _refToDBServInCllctn.clearUserCredentials();
+    this->done(2);
+}
+
+void collectionManager::quitClicked()
+{
+    this->done(0);
 }
 
 void collectionManager::getUserLibs()

--- a/collectionmanager.h
+++ b/collectionmanager.h
@@ -24,6 +24,9 @@ public slots:
     void openClicked();
     void newClicked();
     void deleteClicked();
+    void logoutClicked();
+    void quitClicked();
+
 public:
     collectionManager (databaseService&, QDialog* parent = 0);
     ~collectionManager();
@@ -35,7 +38,7 @@ private:
     QList<QString> libNames;
     int creator_ID;
 
-    Button *openButton, *newButton, *deleteButton;
+    Button *openButton, *newButton, *deleteButton, *logoutButton, *quitButton;
     QListWidget *libraries;
     QDialog *deleteLibDialog;
     QLineEdit *newLibName;

--- a/dbmanager.cpp
+++ b/dbmanager.cpp
@@ -11,12 +11,20 @@ databaseService::databaseService()
     try
     {
         driver = get_driver_instance();
-        connection = driver->connect("host", "user", "password");
+        connection = driver->connect("host", "username", "password");
         connection->setAutoCommit(false);
     }catch(sql::SQLException &ex){
         std::cout << "Connection exception occured " << ex.getErrorCode() << std::endl;
     }
 
+}
+
+void databaseService::clearUserCredentials()
+{
+    sessionUserCredentials.username = "";
+    sessionUserCredentials.password = "";
+    sessionUserCredentials.sqAnswer = "";
+    sessionUserCredentials.ID = 0;
 }
 
 //functions for login manager
@@ -487,4 +495,9 @@ bool databaseService::isTableEmpty()
     rs->close();
     delete stmt;
     delete rs;
+}
+
+void databaseService::clearList()
+{
+    list.clear();
 }

--- a/dbmanager.h
+++ b/dbmanager.h
@@ -21,6 +21,7 @@ class databaseService
 {
 public:
     databaseService();
+    void clearUserCredentials();
 
     //functions for login manager
     bool checkNewUserCredentials(userCreds);
@@ -43,6 +44,7 @@ public:
     void updateRecordInDB(struct record);
     void deleteRecordFromDB(int);
     bool isTableEmpty();
+    void clearList();
 
 
 

--- a/loginmanager.cpp
+++ b/loginmanager.cpp
@@ -5,6 +5,7 @@ loginDialog::loginDialog(databaseService& _refToDBServInConst, QDialog *parent)
     : _refToDBServeInLogin(_refToDBServInConst), QDialog(parent)
 {
     _refToDBServeInLogin = _refToDBServInConst;
+    this->setAttribute(Qt::WA_DeleteOnClose, true);
 
     this->setModal(true);
     this->setFixedSize(450, 250);

--- a/main.cpp
+++ b/main.cpp
@@ -10,26 +10,50 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
+    int loginDialogCode, collectMgrCode, recManagerCode;
     databaseService dbService;
     databaseService& _refToDBService = dbService;
+
+label1:
     loginDialog *dialog = new loginDialog(_refToDBService);
     dialog->show();
+    loginDialogCode = dialog->exec();
 
-    if (dialog->exec() == 1)
+    if (loginDialogCode == 1) //if user succesfully logs in
     {
-        //delete dialog;
+        label2:
         collectionManager *collectMgr = new collectionManager(_refToDBService);
         collectMgr->show();
+        collectMgrCode = collectMgr->exec();
 
-        if (collectMgr->exec() == 1)
+        if (collectMgrCode == 1) //if user succesfully opens a library
         {
             recordManager *recManager = new recordManager(_refToDBService);
             recManager->show();
+            recManagerCode = recManager->exec();
         }
 
+        else if (collectMgrCode == 2) //if user clicks 'Logout'
+        {
+            goto label1;
+        }
+
+        else if (collectMgrCode == 0) //if user clicks 'quit'
+        {
+            return 0;
+        }
+
+        if (recManagerCode == 1) //if user clicks 'Logout'
+        {
+            goto label1;
+        }
+
+        else if (recManagerCode == 2) //if user clicks 'Change Library'
+        {
+            goto label2;
+        }
     }
 
-    return app.exec();
-
+    return 0;
 }
 

--- a/recordmanager.h
+++ b/recordmanager.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <QTableWidgetSelectionRange>
+#include <QDialog>
 
 #include "recordentryfordb.h"
 #include "dbmanager.h"
@@ -18,13 +19,13 @@ class recordTable;
 class dropDownMenu;
 class databaseService;
 
-class recordManager : public QWidget
+class recordManager : public QDialog
 {
     Q_OBJECT
 
 public:
     //recordManager(QWidget *parent = 0);
-    recordManager(databaseService&, QWidget *parent = 0);
+    recordManager(databaseService&, QDialog *parent = 0);
     ~recordManager();
 
     databaseService& _refToDBServInRecMgr;
@@ -42,11 +43,15 @@ private slots:
     void editSelectionClicked();
     void clearEntriesClicked();
     void clearSearchResultsClicked();
-
     void addNewRecordToTable();
+    void logoutClicked();
+    void changeLibraryClicked();
+
 
 private:
     //application widget declarations
+    Button *addNewRecord, *saveChanges, *deleteRecords, *search, *editSelection, *clearEntries, *clearSearchResults,
+           *logoutButton, *changeLibraryButton;
     Button *createButton(const QString& text);
     recordTable *createTable(const char* member, const char* member2, Button *button, Button *button2);
     dropDownMenu *createDropdown();


### PR DESCRIPTION
The changes in this commit allow the user to logout from both the collection manager window and the record manager window. When the user logs out, they are taken back to the main login screen to enter a new username/password, or register a new account. 

This commit also lets users change record collections from the record manager screen by clicking a button 'Change Library'. This brings users back to the collection manager window so they can open, create or delete a new library. This is all done through the use of "QDialog::done(int)" method. Depending on the user action, a different int value is returned by the done() method to main.cpp. Goto statements control the program flow to allow windows to be re-opened.

Proper handling of clearing member variables has also been added, so that when windows are closed, they are fully cleaned out so they can be re-constructed and re-initialized from scratch.